### PR TITLE
Added support for passing an alternate destination URL to redirect to.

### DIFF
--- a/anafero/views.py
+++ b/anafero/views.py
@@ -1,5 +1,6 @@
 import json
 
+from django.conf import settings
 from django.http import HttpResponse
 from django.shortcuts import redirect, get_object_or_404
 from django.template import RequestContext
@@ -50,7 +51,10 @@ def process_referral(request, code):
     referral = get_object_or_404(Referral, code=code)
     session_key = ensure_session_key(request)
     referral.respond(request, "RESPONDED")
-    response = redirect(referral.redirect_to)
+    try:
+        response = redirect(request.GET[getattr(settings, 'ANAFERO_REDIRECT_ATTRIBUTE', 'redirect_to')])
+    except KeyError:
+        response = redirect(referral.redirect_to)
     if request.user.is_anonymous():
         response.set_cookie(
             "anafero-referral",

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -45,3 +45,11 @@ ANAFERO_ACTION_DISPLAY
 
 Defines a dictionary mapping action codes for responses to user-friendly
 display text. Used by the ``action_display`` template filter.
+
+
+ANAFERO_REDIRECT_ATTRIBUTE
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:Default: ``redirect_to``
+
+Defines the URL attribute to retrieve dynamic referral redirection URLs from.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -38,6 +38,13 @@ You can also pass in an optional ``label`` kwarg to ``Referral.create`` if
 you wanted to allow your users to create and manage multiple referrals so
 that labeling them became important to keep track of them.
 
+At runtime, you can append the ``redirect_to`` URL parameter to your referral
+URL to dynamically redirect to an alternate destination.
+
+    {{ user.get_profile.referral.url }}?redirect_to=/special/
+
+The URL parameter used can be altered in your :ref:`settings` file.
+
 
 .. _Referral.record_response:
 


### PR DESCRIPTION
The attached code enables users to pass in a different destination URL to be redirected to for that Referral.

This is useful in instances where an Affiliate wants to temporarily drive traffic to an alternate landing page (perhaps for a special offer or event) but where creating an additional Referral object is overkill.

I've gone ahead and update the documentation for the new feature as well.
