### PR TITLE
compatible user model/ expired_at field

### DIFF
--- a/anafero/models.py
+++ b/anafero/models.py
@@ -20,6 +20,7 @@ class Referral(models.Model):
         null=True)
     label = models.CharField(max_length=100, blank=True)
     code = models.CharField(max_length=40, unique=True)
+    expired_at = models.DateTimeField(null=True)
     redirect_to = models.CharField(max_length=512)
     target_content_type = models.ForeignKey(ContentType, null=True, blank=True)
     target_object_id = models.PositiveIntegerField(null=True, blank=True)


### PR DESCRIPTION
Solves issue 6 & 7.

Issue 6 - user model for foreign key imported via string, if AUTH_USER_MODEL is specified it is used else default django User model import string is used.

7 -  nullable DateTimeField added to Referral model.
