### PR TITLE
make pinax-referrals work with Django 1.10+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,18 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 env:
   - DJANGO=1.8
-  - DJANGO=1.9
   - DJANGO=1.10
+  - DJANGO=1.11
   - DJANGO=master
 matrix:
   exclude:
     - python: "3.3"
-      env: DJANGO=1.9
-    - python: "3.3"
       env: DJANGO=1.10
+    - python: "3.3"
+      env: DJANGO=1.11
     - python: "3.3"
       env: DJANGO=master
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,19 @@ env:
   - DJANGO=master
 matrix:
   exclude:
+    - python: "2.7"
+      env: DJANGO=master
     - python: "3.3"
       env: DJANGO=1.10
     - python: "3.3"
       env: DJANGO=1.11
     - python: "3.3"
+      env: DJANGO=master
+    - python: "3.4"
+      env: DJANGO=master
+    - python: "3.5"
+      env: DJANGO=master
+    - python: "3.6"
       env: DJANGO=master
 install:
   - pip install tox coveralls

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,8 +88,8 @@ Here is an example of these rules applied:
 
     # second set of imports are Django imports with contrib in their own
     # group.
-    from django.core.urlresolvers import reverse
     from django.db import models
+    from django.urls import reverse
     from django.utils import timezone
     from django.utils.translation import ugettext_lazy as _
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,13 +20,15 @@ Add `pinax.referrals.middleware.SessionJumpingMiddleware` in order to link up a
 user who registers and authenticate after hitting the initial referral link.
 Make sure that it comes after the `django.contrib.auth.middleware.AuthenticationMiddleware`:
 
-    MIDDLEWARE_CLASSES = [
+    MIDDLEWARE = [
         ...
         "django.contrib.auth.middleware.AuthenticationMiddleware",
         ...
         "pinax.referrals.middleware.SessionJumpingMiddleware",
         ...
     ]
+
+*Note: use `MIDDLEWARE_CLASSES` instead in case you're still using Django 1.8 or 1.9*
 
 Lastly you will want to add `pinax.referrals.urls` to your urls definition:
 

--- a/pinax/referrals/middleware.py
+++ b/pinax/referrals/middleware.py
@@ -1,9 +1,13 @@
 from django.core.exceptions import ImproperlyConfigured
+try:
+    from django.utils.deprecation import MiddlewareMixin as MIDDLEWARE_BASE_CLASS
+except ImportError:
+    MIDDLEWARE_BASE_CLASS = object
 
 from .models import Referral
 
 
-class SessionJumpingMiddleware(object):
+class SessionJumpingMiddleware(MIDDLEWARE_BASE_CLASS):
 
     def process_request(self, request):
         if not hasattr(request, "user"):

--- a/pinax/referrals/models.py
+++ b/pinax/referrals/models.py
@@ -1,7 +1,12 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.core.urlresolvers import reverse
+from django.db.models.deletion import CASCADE
+
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
 
@@ -21,6 +26,7 @@ class Referral(models.Model):
 
     user = models.ForeignKey(
         AUTH_USER_MODEL,
+        on_delete=CASCADE,
         related_name="referral_codes",
         null=True
     )

--- a/pinax/referrals/tests/tests.py
+++ b/pinax/referrals/tests/tests.py
@@ -1,7 +1,35 @@
+import json
+
+from django.contrib.auth import get_user_model
 from django.test import TestCase
+from pinax.referrals.models import Referral
 
 
 class Tests(TestCase):
 
-    def setUp(self):
-        pass
+    def test_create_referral(self):
+        referring_user = get_user_model().objects.create_user('johndoe', 'john@doe.com', 'notsosecret')
+        self.assertTrue(self.client.login(username=referring_user.username, password='notsosecret'))
+
+        response = self.client.post('/', data={'redirect_to': 'https://example.com/'})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/json')
+        json_response = json.loads(response.content.decode('utf-8'))
+        self.assertSetEqual(set(json_response.keys()), {'url', 'code', 'html'})
+
+        self.assertEqual(referring_user.referral_codes.count(), 1)
+        referral = referring_user.referral_codes.first()
+        self.assertEqual(referral.redirect_to, 'https://example.com/')
+        self.assertEqual(json_response['code'], referral.code)
+
+    def test_process_referral_authenticated(self):
+        referral = Referral.create(redirect_to='https://example.com/')
+        self.assertFalse(referral.responses.exists())
+        referred_user = get_user_model().objects.create_user('janedoe', 'jane@doe.com', 'notsosecret')
+        self.assertTrue(self.client.login(username=referred_user.username, password='notsosecret'))
+        response = self.client.get(referral.url)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], 'https://example.com/')
+        self.assertEqual(referral.responses.count(), 1)
+        referral_response = referral.responses.first()
+        self.assertEqual(referral_response.user, referred_user)

--- a/pinax/referrals/views.py
+++ b/pinax/referrals/views.py
@@ -1,9 +1,6 @@
-import json
-
 from django.conf import settings
-from django.http import HttpResponse
+from django.http import JsonResponse
 from django.shortcuts import redirect, get_object_or_404
-from django.template import RequestContext
 from django.template.loader import render_to_string
 from django.views.decorators.http import require_POST
 
@@ -37,18 +34,15 @@ def create_referral(request):
         target=target
     )
 
-    return HttpResponse(
-        json.dumps({
-            "url": referral.url,
-            "code": referral.code,
-            "html": render_to_string(
-                "pinax/referrals/_create_referral_form.html",
-                ctx,
-                context_instance=RequestContext(request)
-            )
-        }),
-        mimetype="application/json"
-    )
+    return JsonResponse({
+        "url": referral.url,
+        "code": referral.code,
+        "html": render_to_string(
+            "pinax/referrals/_create_referral_form.html",
+            context=ctx,
+            request=request
+        )
+    })
 
 
 def process_referral(request, code):

--- a/runtests.py
+++ b/runtests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import os
 import sys
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 import django
 
@@ -34,7 +34,7 @@ DEFAULT_SETTINGS = dict(
     ]
 )
 
-if StrictVersion(django.__version__) < StrictVersion('1.10'):
+if LooseVersion(django.__version__) < LooseVersion('1.10'):
     DEFAULT_SETTINGS['MIDDLEWARE_CLASSES'] = [
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',

--- a/runtests.py
+++ b/runtests.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import sys
+from distutils.version import StrictVersion
 
 import django
 
@@ -11,6 +12,7 @@ DEFAULT_SETTINGS = dict(
     INSTALLED_APPS=[
         "django.contrib.auth",
         "django.contrib.contenttypes",
+        "django.contrib.sessions",
         "django.contrib.sites",
         "pinax.referrals",
         "pinax.referrals.tests"
@@ -22,10 +24,30 @@ DEFAULT_SETTINGS = dict(
         }
     },
     SITE_ID=1,
-    MIDDLEWARE_CLASSES=[],
     ROOT_URLCONF="pinax.referrals.tests.urls",
     SECRET_KEY="notasecret",
+    TEMPLATES=[
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'APP_DIRS': True,
+        },
+    ]
 )
+
+if StrictVersion(django.__version__) < StrictVersion('1.10'):
+    DEFAULT_SETTINGS['MIDDLEWARE_CLASSES'] = [
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'pinax.referrals.middleware.SessionJumpingMiddleware',
+    ]
+else:
+    DEFAULT_SETTINGS['MIDDLEWARE'] = [
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'pinax.referrals.middleware.SessionJumpingMiddleware',
+    ]
 
 
 def runtests(*test_args):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     license="MIT",
     packages=find_packages(),
     install_requires=[
-        "django-appconf==1.0.1",
+        "django-appconf>=1.0.1",
         "Django>=1.8",
     ],
     package_data={

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ exclude = migrations/*,docs/*
 
 [tox]
 envlist =
-    py27-{1.8,1.10,1.11,master},
+    py27-{1.8,1.10,1.11},
     py33-{1.8},
     py34-{1.8,1.10,1.11,master},
     py35-{1.8,1.10,1.11,master},

--- a/tox.ini
+++ b/tox.ini
@@ -6,18 +6,19 @@ exclude = migrations/*,docs/*
 
 [tox]
 envlist =
-    py27-{1.8,1.9,1.10,master},
+    py27-{1.8,1.10,1.11,master},
     py33-{1.8},
-    py34-{1.8,1.9,1.10,master},
-    py35-{1.8,1.9,1.10,master}
+    py34-{1.8,1.10,1.11,master},
+    py35-{1.8,1.10,1.11,master},
+    py36-{1.8,1.10,1.11,master}
 
 [testenv]
 deps =
-    coverage == 4.2
-    flake8 == 3.0.4
+    coverage == 4.4.1
+    flake8 == 3.3.0
     1.8: Django>=1.8,<1.9
-    1.9: Django>=1.9,<1.10
     1.10: Django>=1.10,<1.11
+    1.11: Django>=1.11,<1.12
     master: https://github.com/django/django/tarball/master
 usedevelop = True
 setenv =


### PR DESCRIPTION
* added simple tests for creating and processing referrals
* fixes #30 through django.utils.deprecation.MiddlewareMixin for now
* avoid TypeError: render_to_string() got an unexpected keyword argument 'context_instance'
* adjusted tox.ini to currently supported python and django versions