### PR TITLE
ReferralResponseAdmin: add select/prefetch_related speed up admin

### DIFF
--- a/pinax/referrals/admin.py
+++ b/pinax/referrals/admin.py
@@ -47,6 +47,14 @@ class ReferralResponseAdmin(admin.ModelAdmin):
         "ip_address",
     ]
 
+    list_select_related = [
+        "referral__user",
+        "user",
+    ]
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).prefetch_related('target')
+
     def target_object_link(self, obj):
         if obj.pk and obj.target:
             admin_link = reverse("admin:%s_%s_change" % (obj.target_content_type.app_label, obj.target_content_type.model), args=(obj.target.pk,))


### PR DESCRIPTION
Current ReferralResponseAdmin changelist view has performance problem with large number of DB queries. This fixes that by retrieving all items in one query.