### PR TITLE
Adding an option to set cookie expiry

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,4 @@ Charles Thompson <cpkthompson@gmail.com>
 Petr Dlouhý <petr.dlouhy@email.cz>
 Christoph Krybus <ckrybus@googlemail.com>
 Ilya Peterov <ipeterov1@gmail.com>
+Pavitrakumar <pavitrakumar78@gmail.com>

--- a/README.md
+++ b/README.md
@@ -390,6 +390,10 @@ You may need to do this if you use a custom user model and upgrade Django.
 
 ## Change Log
 
+### 4.0.2
+
+* Added setting to set the cookie's max age in client's browser
+
 ### 4.0.1
 
 * Changes to admin.py and models.py to increase overridability

--- a/README.md
+++ b/README.md
@@ -212,6 +212,12 @@ system more fine grained.
 
 ### Settings
 
+#### `PINAX_COOKIE_MAX_AGE`
+
+Defaults to `None`
+
+The total amount of time (in seconds) the cookie lasts in the client's browser.
+
 #### `PINAX_REFERRALS_IP_ADDRESS_META_FIELD`
 
 Defaults to `"HTTP_X_FORWARDED_FOR"`

--- a/pinax/referrals/admin.py
+++ b/pinax/referrals/admin.py
@@ -17,8 +17,8 @@ class ReferralAdmin(admin.ModelAdmin):
         "url",
     ]
     readonly_fields = ["code", "created_at"]
-    list_filter = ["target_content_type"]
-    search_fields = ["user__username", "user__email", "code"]
+    list_filter = ["target_content_type", "created_at"]
+    search_fields = ["user__first_name", "user__last_name", "user__email", "user__username", "code"]
     autocomplete_fields = ["user"]
 
 
@@ -33,13 +33,17 @@ class ReferralResponseAdmin(admin.ModelAdmin):
         "target_object_link",
     ]
     readonly_fields = ["referral", "session_key", "user", "ip_address", "action", "target_object_link"]
-    list_filter = ["action"]
+    list_filter = ["action", "created_at"]
     search_fields = [
         "referral__code",
         "referral__user__email",
         "referral__user__username",
+        "referral__user__first_name",
+        "referral__user__last_name",
         "user__email",
         "user__username",
+        "user__first_name",
+        "user__last_name",
         "ip_address",
     ]
 

--- a/pinax/referrals/admin.py
+++ b/pinax/referrals/admin.py
@@ -17,8 +17,8 @@ class ReferralAdmin(admin.ModelAdmin):
         "url",
     ]
     readonly_fields = ["code", "created_at"]
-    list_filter = ["target_content_type", "created_at"]
-    search_fields = ["user__first_name", "user__last_name", "user__email", "user__username", "code"]
+    list_filter = ["target_content_type"]
+    search_fields = ["user__username", "user__email", "code"]
     autocomplete_fields = ["user"]
 
 
@@ -33,17 +33,13 @@ class ReferralResponseAdmin(admin.ModelAdmin):
         "target_object_link",
     ]
     readonly_fields = ["referral", "session_key", "user", "ip_address", "action", "target_object_link"]
-    list_filter = ["action", "created_at"]
+    list_filter = ["action"]
     search_fields = [
         "referral__code",
         "referral__user__email",
         "referral__user__username",
-        "referral__user__first_name",
-        "referral__user__last_name",
         "user__email",
         "user__username",
-        "user__first_name",
-        "user__last_name",
         "ip_address",
     ]
 

--- a/pinax/referrals/views.py
+++ b/pinax/referrals/views.py
@@ -48,6 +48,7 @@ def process_referral(request, code):
     referral = get_object_or_404(Referral, code=code)
     session_key = ensure_session_key(request)
     referral.respond(request, "RESPONDED")
+    max_age = getattr(settings, "PINAX_COOKIE_MAX_AGE", None)
     try:
         response = redirect(request.GET[
             getattr(settings, "PINAX_REFERRALS_REDIRECT_ATTRIBUTE", "redirect_to")]
@@ -57,7 +58,8 @@ def process_referral(request, code):
     if request.user.is_anonymous:
         response.set_cookie(
             "pinax-referral",
-            f"{code}:{session_key}"
+            f"{code}:{session_key}",
+            max_age=max_age
         )
     else:
         response.delete_cookie("pinax-referral")

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-VERSION = "4.0.1"
+VERSION = "4.0.2"
 LONG_DESCRIPTION = """
 .. image:: http://pinaxproject.com/pinax-design/patches/pinax-referrals.svg
     :target: https://pypi.python.org/pypi/pinax-referrals/


### PR DESCRIPTION
Changes proposed in this PR:

- Added  the `PINAX_COOKIE_MAX_AGE` 
- Used `PINAX_COOKIE_MAX_AGE` in `views.py`'s `set_cookie` method to set the expiry of cookie. 