### PR TITLE
fix AttributeError when request is WSGIRequest

### DIFF
--- a/pinax/referrals/models.py
+++ b/pinax/referrals/models.py
@@ -92,7 +92,7 @@ class Referral(models.Model):
 
     @classmethod
     def referral_responses_for_request(cls, request):
-        if request.user.is_authenticated:
+        if hasattr(request, "user") and request.user.is_authenticated:
             qs = ReferralResponse.objects.filter(user=request.user)
         else:
             qs = ReferralResponse.objects.filter(session_key=request.session.session_key)

--- a/pinax/referrals/tests/test_models.py
+++ b/pinax/referrals/tests/test_models.py
@@ -1,0 +1,30 @@
+from django.test import RequestFactory, TestCase
+
+from pinax.referrals.models import Referral
+
+from model_bakery import baker
+
+
+class ReferralTests(TestCase):
+    def test_referral_responses_for_request_no_user(self):
+        # Create a referral with a blank user
+        request = RequestFactory().get("/referral/")
+        request.session = self.client.session
+        baker.make("ReferralResponse", session_key=request.session.session_key)
+        baker.make("ReferralResponse", user=baker.make("User"))
+        queryset = Referral.referral_responses_for_request(request)
+        self.assertEqual(queryset.count(), 1)
+        self.assertEqual(queryset.get().session_key, request.session.session_key)
+        self.assertEqual(queryset.get().user, None)
+
+    def test_referral_responses_for_request_user(self):
+        # Create a referral with a user
+        request = RequestFactory().get("/referral/")
+        request.session = self.client.session
+        request.user = baker.make("User")
+        baker.make("ReferralResponse", user=request.user, session_key="foo_bar")
+        baker.make("ReferralResponse", session_key="session_key")
+        queryset = Referral.referral_responses_for_request(request)
+        self.assertEqual(queryset.count(), 1)
+        self.assertEqual(queryset.get().user, request.user)
+        self.assertEqual(queryset.get().session_key, "foo_bar")

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,1 @@
+model_bakery

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ deps =
     dj40: Django>=4.0,<4.1
     dj41: Django>=4.1,<4.2
     master: https://github.com/django/django/tarball/master
+    -r requirements_test.txt
 
 usedevelop = True
 commands =


### PR DESCRIPTION
When I run my app through WSGIRequest, I sometimes got AttributeError on getting `request.user`. This fixes that problem.