### PR TITLE
Add referral parameter to generate_code callback closes #41, closes #59

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,11 +245,8 @@ Defaults to `"pinax.referrals.callbacks.generate_code"`
 Externalizes the logic that generates the referral code. `pinax-referrals` ships
 with a default that will generate a random 40-character alpha-numeric
 string that can also be used as a reference implementation. The callable
-defined by the fully qualified path is passed a single parameter that is
-the class of the referral model, or `Referral`. This is done as a pure
-convenience so as to alleviate the need for you to have to import it
-should you need it (and you most likely will if you want to be
-certain of uniqueness).
+defined by the fully qualified path is passed the class of the referral model (or `Referral`)
+and the actual referral model instance.
 
 #### `PINAX_REFERRALS_ACTION_DISPLAY`
 
@@ -399,6 +396,10 @@ You may need to do this if you use a custom user model and upgrade Django.
 
 
 ## Change Log
+
+### Unreleased
+
+* Added referral model instance parameter to `generate_code` callback (`PINAX_REFERRALS_CODE_GENERATOR_CALLBACK` variable)
 
 ### 4.1.0 (2022-12-12)
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,17 @@ Externalizes the logic that generates the referral code. `pinax-referrals` ships
 with a default that will generate a random 40-character alpha-numeric
 string that can also be used as a reference implementation. The callable
 defined by the fully qualified path is passed the class of the referral model (or `Referral`)
-and the actual referral model instance.
+and the actual referral model instance. This means that you can easily customize the code for each user.
+
+For example:
+
+```python
+def generate_code(referral_class, referral):
+    return referral.user.username
+```
+
+Since only one Referral with the same code can exist at the same time the value
+returned by `generate_code` needs to be unique.
 
 #### `PINAX_REFERRALS_ACTION_DISPLAY`
 

--- a/pinax/referrals/callbacks.py
+++ b/pinax/referrals/callbacks.py
@@ -3,7 +3,7 @@ import random
 from .conf import settings
 
 
-def generate_code(referral_class):
+def generate_code(referral_class, referral):
     def _generate_code():
         t = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLOMNOPQRSTUVWXYZ1234567890"
         return "".join([random.choice(t) for i in range(40)])

--- a/pinax/referrals/models.py
+++ b/pinax/referrals/models.py
@@ -1,3 +1,5 @@
+from inspect import getfullargspec
+
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
@@ -62,7 +64,9 @@ class Referral(models.Model):
 
     def save(self, *args, **kwargs):
         if not self.code:
-            self.code = settings.PINAX_REFERRALS_CODE_GENERATOR_CALLBACK(Referral)
+            func = settings.PINAX_REFERRALS_CODE_GENERATOR_CALLBACK
+            func_args = [Referral] if len(getfullargspec(func).args) == 1 else [Referral, self]
+            self.code = func(*func_args)
         return super().save(*args, **kwargs)
 
     @classmethod


### PR DESCRIPTION
Closes #59, Closes #41

I've decided to add a new `referral` parameter to the `generate_code` fallback  **in addition to** the `referral_class` parameter even though the model class could be theoretically obtained through `referral.__class__` for backwards compatibility reasons.

Using `def generate_code(referral):` would be my preferred solution if it was a new callback.

